### PR TITLE
fix/modified-network-mode

### DIFF
--- a/terraform/gke/base.tf
+++ b/terraform/gke/base.tf
@@ -1,3 +1,4 @@
+#Tests
 variable "project_name" {}
 
 provider "google" {
@@ -26,6 +27,7 @@ resource "google_container_cluster" "primary" {
   # node pool and immediately delete it.
   remove_default_node_pool = true
   initial_node_count       = 1
+  networking_mode          = "VPC_NATIVE"
 }
 
 resource "google_container_node_pool" "primary_preemptible_nodes" {


### PR DESCRIPTION
When creating a GKE Cluster via REST API the default option for the network is route based, which is not recommended by Google and will cause issues in the future. Added new parameter to set it to VPC_NATIVE.